### PR TITLE
update hdp to version 2.6.2

### DIFF
--- a/conf/autobuild.json
+++ b/conf/autobuild.json
@@ -5,13 +5,13 @@
         "local_user": "root",
         "repos": {
           "cask-tracker": {
-            "branch": "release/0.6"
+            "branch": "develop"
           },
           "cdap-navigator": {
-            "branch": "release/0.7"
+            "branch": "develop"
           },
           "hydrator-plugins": {
-            "branch": "release/1.8"
+            "branch": "develop"
           }
         }
       }

--- a/conf/dsth25.json
+++ b/conf/dsth25.json
@@ -2,7 +2,7 @@
   "config": {
     "hadoop": {
       "distribution": "hdp",
-      "distribution_version": "2.5.3.0"
+      "distribution_version": "2.5.6.0"
     },
     "hive": {
       "hive_site": {

--- a/conf/dsth26.json
+++ b/conf/dsth26.json
@@ -2,7 +2,7 @@
   "config": {
     "hadoop": {
       "distribution": "hdp",
-      "distribution_version": "2.6.1.0"
+      "distribution_version": "2.6.2.0"
     },
     "hive": {
       "hive_site": {


### PR DESCRIPTION
Add support for HDP 2.6.2-205.

http://s3.amazonaws.com/public-repo-1.hortonworks.com/index.html#/HDP/centos7/2.x/updates/2.6.2.0
