### PR TITLE
cdap-12371 workaround for yarn.app.mapreduce.am.staging-dir

### DIFF
--- a/conf/cm511.json
+++ b/conf/cm511.json
@@ -1,7 +1,14 @@
 {
   "config": {
     "cloudera_manager": {
-      "distribution_version": "5.11"
+      "distribution_version": "5.11",
+      "services": {
+        "yarn": {
+          "serviceConfigs": {
+            "yarn_service_mapred_safety_valve": "<property><name>yarn.app.mapreduce.am.staging-dir</name><value>/user</value></property>"
+          }
+        }
+      }
     }
   }
 }

--- a/conf/cm512.json
+++ b/conf/cm512.json
@@ -1,7 +1,14 @@
 {
   "config": {
     "cloudera_manager": {
-      "distribution_version": "5.12"
+      "distribution_version": "5.12",
+      "services": {
+        "yarn": {
+          "serviceConfigs": {
+            "yarn_service_mapred_safety_valve": "<property><name>yarn.app.mapreduce.am.staging-dir</name><value>/user</value></property>"
+          }
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
This applies the workaround recommended in https://issues.cask.co/browse/CDAP-12371 to the two CM versions that need it.  I could've added it to the template, but decided to keep it minimal in hopes this wont always be necessary.  See https://issues.cask.co/browse/CDAP-12371 for more details.