### PR TITLE
Revert "cdap-12371 workaround for yarn.app.mapreduce.am.staging-dir"

### DIFF
--- a/conf/cm511.json
+++ b/conf/cm511.json
@@ -1,14 +1,7 @@
 {
   "config": {
     "cloudera_manager": {
-      "distribution_version": "5.11",
-      "services": {
-        "yarn": {
-          "serviceConfigs": {
-            "yarn_service_mapred_safety_valve": "<property><name>yarn.app.mapreduce.am.staging-dir</name><value>/user</value></property>"
-          }
-        }
-      }
+      "distribution_version": "5.11"
     }
   }
 }

--- a/conf/cm512.json
+++ b/conf/cm512.json
@@ -1,14 +1,7 @@
 {
   "config": {
     "cloudera_manager": {
-      "distribution_version": "5.12",
-      "services": {
-        "yarn": {
-          "serviceConfigs": {
-            "yarn_service_mapred_safety_valve": "<property><name>yarn.app.mapreduce.am.staging-dir</name><value>/user</value></property>"
-          }
-        }
-      }
+      "distribution_version": "5.12"
     }
   }
 }


### PR DESCRIPTION
Reverts caskdata/cdap-integration-tests#837, since @chtyim has a [fix in CDAP](https://github.com/caskdata/cdap/pull/9623) for https://issues.cask.co/browse/CDAP-12371.