### PR TITLE
update hdp to version 2.6.2 and 2.5.6

### DIFF
--- a/conf/dsth25.json
+++ b/conf/dsth25.json
@@ -2,7 +2,7 @@
   "config": {
     "hadoop": {
       "distribution": "hdp",
-      "distribution_version": "2.5.3.0"
+      "distribution_version": "2.5.6.0"
     },
     "hive": {
       "hive_site": {

--- a/conf/dsth26.json
+++ b/conf/dsth26.json
@@ -2,7 +2,7 @@
   "config": {
     "hadoop": {
       "distribution": "hdp",
-      "distribution_version": "2.6.1.0"
+      "distribution_version": "2.6.2.0"
     },
     "hive": {
       "hive_site": {


### PR DESCRIPTION
Use HDP 2.6.2 and 2.5.6.0

http://s3.amazonaws.com/public-repo-1.hortonworks.com/index.html#/HDP/centos7/2.x/updates/2.6.2.0

caskdata/hadoop_cookbook#348 and caskdata/cdap_cookbook#260 have been merged and released