### PR TITLE
shorten delegation token renewal intervals for CM-based builds, same …

### DIFF
--- a/conf/cloudera_manager.json
+++ b/conf/cloudera_manager.json
@@ -6,6 +6,16 @@
           "serviceConfigs": {
             "csd_compatibility_check_enabled": "false"
           }
+        },
+        "hdfs": {
+          "serviceConfigs": {
+            "hdfs_service_config_safety_valve": "<property><name>dfs.namenode.delegation.token.renew-interval</name><value>600000</value></property><property><name>dfs.namenode.delegation.token.max-lifetime</name><value>1200000</value></property>"
+          }
+        },
+        "hbase": {
+          "serviceConfigs": {
+            "hbase_service_config_safety_valve": "<property><name>hbase.auth.key.update.interval</name><value>600000</value></property>"
+          }
         }
       }
     }


### PR DESCRIPTION
…as we do for non-CM ITN

Set delegation renewal intervals for CM-based builds.  The same properties get set via https://github.com/caskdata/cdap-integration-tests/blob/release/4.3/conf/cdap.json for non-CM ITN builds.  For some reason, these properties are not exposed in CM and must be set in safety valves.