### PR TITLE
set client-side delegation token renew intervals for hdfs/hbase

### DIFF
--- a/conf/cloudera_manager.json
+++ b/conf/cloudera_manager.json
@@ -10,11 +10,25 @@
         "hdfs": {
           "serviceConfigs": {
             "hdfs_service_config_safety_valve": "<property><name>dfs.namenode.delegation.token.renew-interval</name><value>600000</value></property><property><name>dfs.namenode.delegation.token.max-lifetime</name><value>1200000</value></property>"
+          },
+          "roles": {
+            "gateway": {
+              "configs": {
+                "hdfs_client_config_safety_valve": "<property><name>dfs.namenode.delegation.token.renew-interval</name><value>600000</value></property><property><name>dfs.namenode.delegation.token.max-lifetime</name><value>1200000</value></property>"
+              }
+            }
           }
         },
         "hbase": {
           "serviceConfigs": {
             "hbase_service_config_safety_valve": "<property><name>hbase.auth.key.update.interval</name><value>600000</value></property>"
+          },
+          "roles": {
+            "gateway": {
+              "configs": {
+                "hbase_client_config_safety_valve": "<property><name>hbase.auth.key.update.interval</name><value>600000</value></property>"
+              }
+            }
           }
         }
       }


### PR DESCRIPTION
continuation of #843, the delegation token renewal settings must actually be set it 2 different safety_valves.  this PR adds the second safety_valve location, which is for the client *-site.xml given to CDAP.

This "fixes" https://issues.cask.co/browse/CDAP-12683