### PR TITLE
Feature/reduce yarn delegation token renew

### DIFF
--- a/conf/cdap.json
+++ b/conf/cdap.json
@@ -15,6 +15,10 @@
       "hdfs_site": {
         "dfs.namenode.delegation.token.renew-interval": "600000",
         "dfs.namenode.delegation.token.max-lifetime": "1200000"
+      },
+      "yarn_site": {
+        "yarn.resourcemanager.delegation.token.renew-interval": "600000",
+        "yarn.resourcemanager.delegation.token.max-lifetime": "1200000"
       }
     },
     "hbase": {

--- a/conf/cloudera_manager.json
+++ b/conf/cloudera_manager.json
@@ -30,6 +30,18 @@
               }
             }
           }
+        },
+        "yarn": {
+          "serviceConfigs": {
+            "yarn_service_config_safety_valve": "<property><name>yarn.resourcemanager.delegation.token.renew-interval</name><value>600000</value></property><property><name>yarn.resourcemanager.delegation.token.max-lifetime</name><value>1200000</value></property>"
+          },
+          "roles": {
+            "gateway": {
+              "configs": {
+                "yarn_client_config_safety_valve": "<property><name>yarn.resourcemanager.delegation.token.renew-interval</name><value>600000</value></property><property><name>yarn.resourcemanager.delegation.token.max-lifetime</name><value>1200000</value></property>"
+              }
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
- [x] Sets yarn delegation token renew interval to 10min, as we do for HDFS/HBase
- [x] update for both ITN and ITNCM

This is for release/4.3 but will backport/merge to other branches including develop