### PR TITLE
configure delegation token renewals in roleconfiggroup instead of ind…

### DIFF
--- a/conf/cloudera_manager.json
+++ b/conf/cloudera_manager.json
@@ -11,8 +11,8 @@
           "serviceConfigs": {
             "hdfs_service_config_safety_valve": "<property><name>dfs.namenode.delegation.token.renew-interval</name><value>600000</value></property><property><name>dfs.namenode.delegation.token.max-lifetime</name><value>1200000</value></property>"
           },
-          "roles": {
-            "gateway": {
+          "roleConfigGroups": {
+            "gateway-base": {
               "configs": {
                 "hdfs_client_config_safety_valve": "<property><name>dfs.namenode.delegation.token.renew-interval</name><value>600000</value></property><property><name>dfs.namenode.delegation.token.max-lifetime</name><value>1200000</value></property>"
               }
@@ -23,8 +23,8 @@
           "serviceConfigs": {
             "hbase_service_config_safety_valve": "<property><name>hbase.auth.key.update.interval</name><value>600000</value></property>"
           },
-          "roles": {
-            "gateway": {
+          "roleConfigGroups": {
+            "gateway-base": {
               "configs": {
                 "hbase_client_config_safety_valve": "<property><name>hbase.auth.key.update.interval</name><value>600000</value></property>"
               }
@@ -35,8 +35,8 @@
           "serviceConfigs": {
             "yarn_service_config_safety_valve": "<property><name>yarn.resourcemanager.delegation.token.renew-interval</name><value>600000</value></property><property><name>yarn.resourcemanager.delegation.token.max-lifetime</name><value>1200000</value></property>"
           },
-          "roles": {
-            "gateway": {
+          "roleConfigGroups": {
+            "gateway-base": {
               "configs": {
                 "yarn_client_config_safety_valve": "<property><name>yarn.resourcemanager.delegation.token.renew-interval</name><value>600000</value></property><property><name>yarn.resourcemanager.delegation.token.max-lifetime</name><value>1200000</value></property>"
               }


### PR DESCRIPTION
…ividual roles, so that CM generates these for CDAP services

requires https://github.com/caskdata/coopr-internal/pull/632

this is the proper fix for https://issues.cask.co/browse/CDAP-12683.  Previously we added the token renewal configurations to the individual gateway roles on each node.  The problem is, CM generates them for /etc/[service]/conf, but not when it generates the client config for cdap services in the process directories.  By configuring them in the roleConfigGroup instead, CM generates these configs in the process directories for the cdap services.

This will need to be backported