### PR TITLE
configure delegation token renewals in roleconfiggroup instead of ind…

### DIFF
--- a/conf/cloudera_manager.json
+++ b/conf/cloudera_manager.json
@@ -11,8 +11,8 @@
           "serviceConfigs": {
             "hdfs_service_config_safety_valve": "<property><name>dfs.namenode.delegation.token.renew-interval</name><value>600000</value></property><property><name>dfs.namenode.delegation.token.max-lifetime</name><value>1200000</value></property>"
           },
-          "roles": {
-            "gateway": {
+          "roleConfigGroups": {
+            "gateway-base": {
               "configs": {
                 "hdfs_client_config_safety_valve": "<property><name>dfs.namenode.delegation.token.renew-interval</name><value>600000</value></property><property><name>dfs.namenode.delegation.token.max-lifetime</name><value>1200000</value></property>"
               }
@@ -23,8 +23,8 @@
           "serviceConfigs": {
             "hbase_service_config_safety_valve": "<property><name>hbase.auth.key.update.interval</name><value>600000</value></property>"
           },
-          "roles": {
-            "gateway": {
+          "roleConfigGroups": {
+            "gateway-base": {
               "configs": {
                 "hbase_client_config_safety_valve": "<property><name>hbase.auth.key.update.interval</name><value>600000</value></property>"
               }
@@ -35,8 +35,8 @@
           "serviceConfigs": {
             "yarn_service_config_safety_valve": "<property><name>yarn.resourcemanager.delegation.token.renew-interval</name><value>600000</value></property><property><name>yarn.resourcemanager.delegation.token.max-lifetime</name><value>1200000</value></property>"
           },
-          "roles": {
-            "gateway": {
+          "roleConfigGroups": {
+            "gateway-base": {
               "configs": {
                 "yarn_client_config_safety_valve": "<property><name>yarn.resourcemanager.delegation.token.renew-interval</name><value>600000</value></property><property><name>yarn.resourcemanager.delegation.token.max-lifetime</name><value>1200000</value></property>"
               }


### PR DESCRIPTION
…ividual roles, so that CM generates these for CDAP services

backport of https://github.com/caskdata/cdap-integration-tests/pull/851, no conflicts