### PR TITLE
add security.authorization.admin.users for cdapitn for 4.2

### DIFF
--- a/conf/cloudera_manager.json
+++ b/conf/cloudera_manager.json
@@ -2,6 +2,11 @@
   "config": {
     "cloudera_manager": {
       "services": {
+        "cdap": {
+          "serviceConfigs": {
+            "security.authorization.admin.users": "cdapitn"
+          }
+        },
         "hdfs": {
           "serviceConfigs": {
             "hdfs_service_config_safety_valve": "<property><name>dfs.namenode.delegation.token.renew-interval</name><value>600000</value></property><property><name>dfs.namenode.delegation.token.max-lifetime</name><value>1200000</value></property>"


### PR DESCRIPTION
add `cdapitn` to `security.authorization.admin.users` for 4.2 certification builds.  This way, cdapitn will be an admin on the clusters spun up by the certification build.  (this is 4.2 and below)