### PR TITLE
add cdap user to sentry.service.admin.group

### DIFF
--- a/conf/cloudera_manager.json
+++ b/conf/cloudera_manager.json
@@ -31,6 +31,11 @@
             }
           }
         },
+        "sentry": {
+          "serviceConfigs": {
+            "sentry.service.admin.group": "hive,impala,hue,solr,cdap,cdapitn"
+          }
+        },
         "yarn": {
           "serviceConfigs": {
             "yarn_service_config_safety_valve": "<property><name>yarn.resourcemanager.delegation.token.renew-interval</name><value>600000</value></property><property><name>yarn.resourcemanager.delegation.token.max-lifetime</name><value>1200000</value></property>"


### PR DESCRIPTION
overrides `sentry.service.admin.group`, to add user `cdap`.  This is needed for CDAP 4.2.

Requires https://github.com/caskdata/coopr-internal/pull/634