### PR TITLE
Revert "Use Cask's JDK/JCE mirrors"

### DIFF
--- a/conf/all.json
+++ b/conf/all.json
@@ -1,35 +1,7 @@
 {
   "config": {
     "java": {
-      "install_flavor": "oracle",
-      "jdk_version": 7,
-      "jdk": {
-        "7": {
-          "x86_64": {
-            "url": "https://downloads.cask.co/jdk/jdk-7u75-linux-x64.tar.gz",
-            "checksum": "460959219b534dc23e34d77abc306e180b364069b9fc2b2265d964fa2c281610"
-          }
-        },
-        "8": {
-          "x86_64": {
-            "url": "https://downloads.cask.co/jdk/jdk-8u101-linux-x64.tar.gz",
-            "checksum": "467f323ba38df2b87311a7818bcbf60fe0feb2139c455dfa0e08ba7ed8581328"
-          }
-        }
-      },
-      "oracle": {
-        "accept_oracle_download_terms": true,
-        "jce": {
-          "7": {
-            "url": "https://downloads.cask.co/jdk/UnlimitedJCEPolicyJDK7.zip",
-            "checksum": "7a8d790e7bd9c2f82a83baddfae765797a4a56ea603c9150c87b7cdb7800194d"
-          },
-          "8": {
-            "url": "https://downloads.cask.co/jdk/jce_policy-8.zip",
-            "checksum": "f3020a3922efd6626c2fff45695d527f34a8020e938a49292561f18ad1320b59"
-          }
-        }
-      }
+      "install_flavor": "openjdk"
     }
   },
   "provider-fields": {

--- a/conf/all.json
+++ b/conf/all.json
@@ -1,9 +1,4 @@
 {
-  "config": {
-    "java": {
-      "install_flavor": "openjdk"
-    }
-  },
   "provider-fields": {
     "bootstrap_interface": "bind_v4",
     "zone_name": "us-east1-c"


### PR DESCRIPTION
This PR reverts https://github.com/caskdata/cdap-integration-tests/pull/752 and https://github.com/caskdata/cdap-integration-tests/pull/743.

Instead, the templates are updated with these changes: https://github.com/caskdata/coopr-internal/pull/571