### PR TITLE
unconstrain hive version as no longer needed

### DIFF
--- a/conf/dstm50.json
+++ b/conf/dstm50.json
@@ -5,9 +5,6 @@
     },
     "hbase": {
       "version": "0.98.12.201606022139-1"
-    },
-    "hive": {
-      "version": "1.2.201706270939-1"
     }
   },
   "provider-fields": {

--- a/conf/dstm51.json
+++ b/conf/dstm51.json
@@ -2,9 +2,6 @@
   "config": {
     "hadoop_mapr": {
       "distribution_version": "5.1.0"
-    },
-    "hive": {
-      "version": "1.2.201706270939-1"
     }
   },
   "provider-fields": {


### PR DESCRIPTION
these versions were added in https://github.com/caskdata/cdap-integration-tests/pull/808 when a hive 2.0 was introduced to the repo.  This appears to have been removed, (and 1.2 updated), so just removing this constraint