### PR TITLE
exclude netty-all dependecy in hadoop-hdfs, this was pulling in 4.0 n…

### DIFF
--- a/integration-test-standalone/pom.xml
+++ b/integration-test-standalone/pom.xml
@@ -138,6 +138,10 @@
           <groupId>com.google.guava</groupId>
           <artifactId>guava</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-all</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>


### PR DESCRIPTION
…etty jar, causing failure during standalone startup test