### PR TITLE
Update cdap.version to 4.3.2, from 4.3.0.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <cdap.pre.version>4.2.0</cdap.pre.version>
-    <cdap.version>4.3.0</cdap.version>
+    <cdap.version>4.3.2</cdap.version>
     <hydrator.version>1.8.0-SNAPSHOT</hydrator.version>
     <tracker.version>0.6.0-SNAPSHOT</tracker.version>
     <!-- cdap.examples.version is overridden in the pre-stage of upgrade tests -->


### PR DESCRIPTION
This is so that we can leverage the fix that happened in CDAP: https://github.com/caskdata/cdap/pull/9706.