### PR TITLE
Simply use the full URI, without stripping the scheme.

### DIFF
--- a/integration-test-remote/src/test/java/co/cask/cdap/app/etl/batch/HivePluginTest.java
+++ b/integration-test-remote/src/test/java/co/cask/cdap/app/etl/batch/HivePluginTest.java
@@ -118,13 +118,10 @@ public class HivePluginTest extends ETLTestBase {
     Assert.assertEquals(200, response.getResponseCode());
     String location =
       new JsonParser().parse(response.getResponseBodyAsString()).getAsJsonObject().get("location").getAsString();
-    // file:/tmp/foo  --> /tmp/foo
-    // hdfs://tmp/foo --> /tmp/foo
-    String locationPath = new URI(location).getPath();
 
     Map<String, String> properties =
       ImmutableMap.of("connectionString", getHiveConnectionString(),
-                      "statement", "LOAD DATA INPATH '" + locationPath + "' INTO TABLE dataset_" + outputDataset);
+                      "statement", "LOAD DATA INPATH '" + location + "' INTO TABLE dataset_" + outputDataset);
 
     // use a pipeline that imports data from one FileSet to the other, using the HiveImport plugin
     ETLStage hiveImport = new ETLStage("HiveImportStage",


### PR DESCRIPTION
Simply use the full URI given from explore service, without stripping the scheme.
Otherwise, on some distros, there is an error saying that the URI doesn't match.
It is an error very similar to https://stackoverflow.com/questions/19431074/hive-not-fully-honoring-fs-default-name-fs-defaultfs-value-in-core-site-xml, where it is basically complaining because one of the URIs will not have the hdfs port, but the other will.