### PR TITLE
Specify the user in the hive jdbc connection string.

### DIFF
--- a/integration-test-remote/src/test/java/co/cask/cdap/app/etl/batch/HivePluginTest.java
+++ b/integration-test-remote/src/test/java/co/cask/cdap/app/etl/batch/HivePluginTest.java
@@ -171,7 +171,7 @@ public class HivePluginTest extends ETLTestBase {
     }
     jdbcURL = jdbcURL.substring(0, firstSlashIndex + 1) + getHiveDatabase() + jdbcURL.substring(firstSemiColon);
 
-    return jdbcURL + ";auth=delegationToken";
+    return jdbcURL + ";auth=delegationToken;user=cdap";
   }
 
   private String getHiveDatabase() {


### PR DESCRIPTION
Otherwise, on a MapR 5.0 cluster, I was seeing the following error:

```
Caused by: org.apache.thrift.protocol.TProtocolException: Required field 'serverProtocolVersion' is unset! Struct:TOpenSessionResp(status:TStatus(statusCode:ERROR_STATUS, infoMessages:[*org.apache.hive.service.cli.HiveSQLException:Failed to open new session: java.lang.RuntimeException: java.lang.RuntimeException: java.io.IOException: Error getting user info for current user, anonymous:13:12, org.apache.hive.service.cli.session.SessionManager:openSession:SessionManager.java:258, org.apache.hive.service.cli.CLIService:openSessionWithImpersonation:CLIService.java:202, org.apache.hive.service.cli.thrift.ThriftCLIService:getSessionHandle:ThriftCLIService.java:408, org.apache.hive.service.cli.thrift.ThriftCLIService:OpenSession:ThriftCLIService.java:302, org.apache.hive.service.cli.thrift.TCLIService$Processor$OpenSession:getResult:TCLIService.java:1257, org.apache.hive.service.cli.thrift.TCLIService$Processor$OpenSession:getResult:TCLIService.java:1242, org.apache.thrift.ProcessFunction:process:ProcessFunction.java:39, org.apache.thrift.TBaseProcessor:process:TBaseProcessor.java:39, org.apache.hive.service.auth.TSetIpAddressProcessor:process:TSetIpAddressProcessor.java:56, org.apache.thrift.server.TThreadPoolServer$WorkerProcess:run:TThreadPoolServer.java:285, java.util.concurrent.ThreadPoolExecutor:runWorker:ThreadPoolExecutor.java:1145, java.util.concurrent.ThreadPoolExecutor$Worker:run:ThreadPoolExecutor.java:615, java.lang.Thread:run:Thread.java:745, *java.lang.RuntimeException:java.lang.RuntimeException: java.io.IOException: Error getting user info for current user, anonymous:21:8, org.apache.hive.service.cli.session.HiveSessionProxy:invoke:HiveSessionProxy.java:83, org.apache.hive.service.cli.session.HiveSessionProxy:access$000:HiveSessionProxy.java:36, org.apache.hive.service.cli.session.HiveSessionProxy$1:run:HiveSessionProxy.java:63, java.security.AccessController:doPrivileged:AccessController.java:-2, javax.security.auth.Subject:doAs:Subject.java:415, org.apache.hadoop.security.UserGroupInformation:doAs:UserGroupInformation.java:1595, org.apache.hive.service.cli.session.HiveSessionProxy:invoke:HiveSessionProxy.java:59, com.sun.proxy.$Proxy10:open::-1, org.apache.hive.service.cli.session.SessionManager:openSession:SessionManager.java:250, *java.lang.RuntimeException:java.io.IOException: Error getting user info for current user, anonymous:27:6, org.apache.hadoop.hive.ql.session.SessionState:start:SessionState.java:525, org.apache.hive.service.cli.session.HiveSessionImpl:open:HiveSessionImpl.java:140, sun.reflect.NativeMethodAccessorImpl:invoke0:NativeMethodAccessorImpl.java:-2, sun.reflect.NativeMethodAccessorImpl:invoke:NativeMethodAccessorImpl.java:57, sun.reflect.DelegatingMethodAccessorImpl:invoke:DelegatingMethodAccessorImpl.java:43, java.lang.reflect.Method:invoke:Method.java:606, org.apache.hive.service.cli.session.HiveSessionProxy:invoke:HiveSessionProxy.java:78, *java.io.IOException:Error getting user info for current user, anonymous:34:7, com.mapr.fs.MapRFileSystem:lookupClient:MapRFileSystem.java:617, com.mapr.fs.MapRFileSystem:lookupClient:MapRFileSystem.java:654, com.mapr.fs.MapRFileSystem:getMapRFileStatus:MapRFileSystem.java:1310, com.mapr.fs.MapRFileSystem:getFileStatus:MapRFileSystem.java:942, org.apache.hadoop.fs.FileSystem:exists:FileSystem.java:1460, org.apache.hadoop.hive.ql.session.SessionState:createRootHDFSDir:SessionState.java:602, org.apache.hadoop.hive.ql.session.SessionState:createSessionDirs:SessionState.java:557, org.apache.hadoop.hive.ql.session.SessionState:start:SessionState.java:511], errorCode:0, errorMessage:Failed to open new session: java.lang.RuntimeException: java.lang.RuntimeException: java.io.IOException: Error getting user info for current user, anonymous), serverProtocolVersion:null)
	at org.apache.hive.service.cli.thrift.TOpenSessionResp.validate(TOpenSessionResp.java:578) ~[na:na]
	at org.apache.hive.service.cli.thrift.TOpenSessionResp$TOpenSessionRespStandardScheme.read(TOpenSessionResp.java:676) ~[na:na]
	at org.apache.hive.service.cli.thrift.TOpenSessionResp$TOpenSessionRespStandardScheme.read(TOpenSessionResp.java:612) ~[na:na]
	at org.apache.hive.service.cli.thrift.TOpenSessionResp.read(TOpenSessionResp.java:520) ~[na:na]
	at org.apache.hive.service.cli.thrift.TCLIService$OpenSession_result$OpenSession_resultStandardScheme.read(TCLIService.java:2281) ~[na:na]
	at org.apache.hive.service.cli.thrift.TCLIService$OpenSession_result$OpenSession_resultStandardScheme.read(TCLIService.java:2266) ~[na:na]
	at org.apache.hive.service.cli.thrift.TCLIService$OpenSession_result.read(TCLIService.java:2213) ~[na:na]
	at org.apache.thrift.TServiceClient.receiveBase(TServiceClient.java:78) ~[org.apache.thrift.libthrift-0.9.3.jar:0.9.3]
	at org.apache.hive.service.cli.thrift.TCLIService$Client.recv_OpenSession(TCLIService.java:156) ~[na:na]
	at org.apache.hive.service.cli.thrift.TCLIService$Client.OpenSession(TCLIService.java:143) ~[na:na]
	at org.apache.hive.jdbc.HiveConnection.openSession(HiveConnection.java:455) ~[na:na]
	at org.apache.hive.jdbc.HiveConnection.<init>(HiveConnection.java:178) ~[na:na]
	at org.apache.hive.jdbc.HiveDriver.connect(HiveDriver.java:105) ~[na:na]
	at java.sql.DriverManager.getConnection(DriverManager.java:571) ~[na:1.7.0_75]
	at java.sql.DriverManager.getConnection(DriverManager.java:215) ~[na:1.7.0_75]
	at co.cask.hydrator.plugin.hive.action.common.HiveCommandExecutor.<init>(HiveCommandExecutor.java:34) ~[na:na]
	at co.cask.hydrator.plugin.hive.action.HiveImport.run(HiveImport.java:59) ~[na:na]
	at co.cask.cdap.etl.common.plugin.WrappedAction$2.call(WrappedAction.java:54) ~[na:na]
	at co.cask.cdap.etl.common.plugin.WrappedAction$2.call(WrappedAction.java:51) ~[na:na]
	at co.cask.cdap.etl.common.plugin.Caller$1.call(Caller.java:30) ~[na:na]
	at co.cask.cdap.etl.common.plugin.StageLoggingCaller.call(StageLoggingCaller.java:40) ~[na:na]
	at co.cask.cdap.etl.common.plugin.WrappedAction.run(WrappedAction.java:51) ~[na:na]
	at co.cask.cdap.etl.batch.customaction.PipelineAction.run(PipelineAction.java:92) ~[na:na]
	at co.cask.cdap.internal.app.runtime.workflow.CustomActionExecutor$2.run(CustomActionExecutor.java:190) ~[na:na]
	at co.cask.cdap.internal.app.runtime.AbstractContext.executeChecked(AbstractContext.java:561) ~[na:na]
	at co.cask.cdap.internal.app.runtime.workflow.CustomActionExecutor.executeCustomAction(CustomActionExecutor.java:187) ~[na:na]
	at co.cask.cdap.internal.app.runtime.workflow.CustomActionExecutor.execute(CustomActionExecutor.java:125) ~[na:na]
	at co.cask.cdap.internal.app.runtime.workflow.WorkflowDriver.executeCustomAction(WorkflowDriver.java:444) ~[na:na]
	at co.cask.cdap.internal.app.runtime.workflow.WorkflowDriver.executeNode(WorkflowDriver.java:467) ~[na:na]
	at co.cask.cdap.internal.app.runtime.workflow.WorkflowDriver.executeAll(WorkflowDriver.java:640) ~[na:na]
	... 3 common frames omitted
```

Relevant: https://stackoverflow.com/questions/27614723/hive2-jdbc-required-field-serverprotocolversion-is-unset