### PR TITLE
prevent Unauthorized connection for super-user: hive

### DIFF
--- a/conf/dsth23.json
+++ b/conf/dsth23.json
@@ -5,7 +5,8 @@
       "distribution_version": "2.3.6.0",
       "core_site": {
         "hadoop.security.authentication": "simple",
-        "hadoop.security.authorization": "false"
+        "hadoop.security.authorization": "false",
+        "hadoop.proxyuser.hive.hosts": "*"
       },
       "hdfs_site": {
         "dfs.webhdfs.enabled": "false"


### PR DESCRIPTION
prevents `Unauthorized connection for super-user: hive from IP 10.210.0.18` happening in hdp 2.3 only.  This setting is already set in hdp 2.4+ via hadoop_wrapper krb5 attributes, as these are all kerberos-enabled