### PR TITLE
newer JSON gem will generate from a string, so updating conditional

### DIFF
--- a/bin/coopr-runner-wrapper.rb
+++ b/bin/coopr-runner-wrapper.rb
@@ -270,12 +270,12 @@ module Cask
           dimension_json.each do |k, v|
             arg_k = "--#{k}"
             # Value may either be json (in the case of --config) or else convertible to string (--services, --initial-lease-time)
-            begin
-              arg_v = JSON.generate(v)
-            rescue JSON::GeneratorError
-              # Not a json object, pass as string
-              arg_v = v.to_s
-            end
+            arg_v = if v.respond_to?(:to_hash) || v.respond_to?(:to_h)
+                      JSON.generate(v)
+                    else
+                      # Not a json object, pass as string
+                      v.to_s
+                    end
             res_args += [arg_k, arg_v]
           end
         rescue => e


### PR DESCRIPTION
JSON gem 2.0.4 in ruby 2.4.3 will generate from a string, though I can't find any supporting docs:

```
irb(main):011:0> JSON.generate('foo')
=> "\"foo\""
```

Updating previous logic that depended on the above throwing an exception, to instead explicitly check for a hash object.