### PR TITLE
Fix compilation errors (Id-related)

### DIFF
--- a/integration-test-core/src/main/java/co/cask/cdap/test/RemoteDatasetAdmin.java
+++ b/integration-test-core/src/main/java/co/cask/cdap/test/RemoteDatasetAdmin.java
@@ -23,7 +23,6 @@ import co.cask.cdap.common.DatasetNotFoundException;
 import co.cask.cdap.common.DatasetTypeNotFoundException;
 import co.cask.cdap.common.UnauthenticatedException;
 import co.cask.cdap.proto.DatasetInstanceConfiguration;
-import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.id.DatasetId;
 import co.cask.cdap.security.spi.authorization.UnauthorizedException;
 import com.google.common.base.Throwables;

--- a/integration-test-remote/src/test/java/co/cask/cdap/app/etl/ETLSystemMetadataTest.java
+++ b/integration-test-remote/src/test/java/co/cask/cdap/app/etl/ETLSystemMetadataTest.java
@@ -68,7 +68,7 @@ public class ETLSystemMetadataTest extends ETLTestBase {
                                                          NamespaceId namespace, String query,
                                                          EntityTypeSimpleName targetType) throws Exception {
     Set<MetadataSearchResultRecord> results =
-      metadataClient.searchMetadata(namespace.toId(), query, targetType).getResults();
+      metadataClient.searchMetadata(namespace, query, targetType).getResults();
     Set<MetadataSearchResultRecord> transformed = new HashSet<>();
     for (MetadataSearchResultRecord result : results) {
       transformed.add(new MetadataSearchResultRecord(result.getEntityId()));

--- a/integration-test-remote/src/test/java/co/cask/cdap/apps/DatasetTest.java
+++ b/integration-test-remote/src/test/java/co/cask/cdap/apps/DatasetTest.java
@@ -22,7 +22,6 @@ import co.cask.cdap.client.config.ClientConfig;
 import co.cask.cdap.common.UnauthenticatedException;
 import co.cask.cdap.examples.wordcount.RetrieveCounts;
 import co.cask.cdap.examples.wordcount.WordCount;
-import co.cask.cdap.gateway.handlers.UsageHandler;
 import co.cask.cdap.proto.DatasetMeta;
 import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.proto.id.DatasetId;
@@ -156,21 +155,15 @@ public class DatasetTest extends AudiTestBase {
   private Set<ProgramId> getPrograms(String endPoint)
     throws IOException, UnauthenticatedException, UnauthorizedException {
     HttpResponse response = makeRequest(endPoint);
-    // CDAP-7316 The handler for this request (UsageHandler) returns results in Id.Program serialized form
-    // for backward compatibility with the help of UsageHandler.BackwardCompatibility.IdProgram class
-    // so verify with that rather than ProgramId class
     return GSON.fromJson(response.getResponseBodyAsString(),
-                         new TypeToken<Set<UsageHandler.BackwardCompatibility.IdProgram>>() { }.getType());
+                         new TypeToken<Set<ProgramId>>() { }.getType());
   }
 
   private Set<DatasetId> getDatasetInstances(String endPoint)
     throws IOException, UnauthenticatedException, UnauthorizedException {
     HttpResponse response = makeRequest(endPoint);
-    // CDAP-7316 The handler for this request (UsageHandler) returns results in Id.DatasetInstance serialized form
-    // for backward compatibility with the help of UsageHandler.BackwardCompatibility.IdDatasetInstance class
-    // so verify with that rather than DatasetId class
     return GSON.fromJson(response.getResponseBodyAsString(),
-                         new TypeToken<Set<UsageHandler.BackwardCompatibility.IdDatasetInstance>>() { }.getType());
+                         new TypeToken<Set<DatasetId>>() { }.getType());
   }
 
   private HttpResponse makeRequest(String endPoint)

--- a/integration-test-remote/src/test/java/co/cask/cdap/apps/spark/sparkpagerank/SparkPageRankAppTest.java
+++ b/integration-test-remote/src/test/java/co/cask/cdap/apps/spark/sparkpagerank/SparkPageRankAppTest.java
@@ -25,11 +25,9 @@ import co.cask.cdap.data2.metadata.lineage.Lineage;
 import co.cask.cdap.data2.metadata.lineage.LineageSerializer;
 import co.cask.cdap.data2.metadata.lineage.Relation;
 import co.cask.cdap.examples.sparkpagerank.SparkPageRankApp;
-import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.proto.RunRecord;
 import co.cask.cdap.proto.codec.NamespacedEntityIdCodec;
-import co.cask.cdap.proto.codec.NamespacedIdCodec;
 import co.cask.cdap.proto.id.ApplicationId;
 import co.cask.cdap.proto.id.DatasetId;
 import co.cask.cdap.proto.id.NamespacedEntityId;
@@ -82,7 +80,6 @@ import java.util.concurrent.TimeUnit;
 })
 public class SparkPageRankAppTest extends AudiTestBase {
   private static final Gson GSON = new GsonBuilder()
-    .registerTypeAdapter(Id.NamespacedId.class, new NamespacedIdCodec())
     .registerTypeAdapter(NamespacedEntityId.class, new NamespacedEntityIdCodec())
     .create();
   private static final String URL_1 = "http://example.com/page1";

--- a/upgrade-test/src/test/java/co/cask/cdap/upgrade/MetadataUpgradeTest.java
+++ b/upgrade-test/src/test/java/co/cask/cdap/upgrade/MetadataUpgradeTest.java
@@ -96,19 +96,19 @@ public class MetadataUpgradeTest extends UpgradeTestBase {
 
     // Add some user metadata
     MetadataClient metadataClient = getMetadataClient();
-    metadataClient.addProperties(PURCHASE_APP.toId(), APP_PROPERTIES);
-    Assert.assertEquals(EXPECTED_APP_METADATA, metadataClient.getMetadata(PURCHASE_APP.toId(), MetadataScope.USER));
+    metadataClient.addProperties(PURCHASE_APP, APP_PROPERTIES);
+    Assert.assertEquals(EXPECTED_APP_METADATA, metadataClient.getMetadata(PURCHASE_APP, MetadataScope.USER));
 
-    metadataClient.addTags(PURCHASE_STREAM.toId(), STREAM_TAGS);
-    Assert.assertEquals(EXPECTED_STREAM_METADATA, metadataClient.getMetadata(PURCHASE_STREAM.toId(), 
+    metadataClient.addTags(PURCHASE_STREAM, STREAM_TAGS);
+    Assert.assertEquals(EXPECTED_STREAM_METADATA, metadataClient.getMetadata(PURCHASE_STREAM, 
                                                                              MetadataScope.USER));
 
-    metadataClient.addTags(PURCHASE_HISTORY_BUILDER.toId(), MR_TAGS);
-    Assert.assertEquals(EXPECTED_MR_METADATA, metadataClient.getMetadata(PURCHASE_HISTORY_BUILDER.toId(), 
+    metadataClient.addTags(PURCHASE_HISTORY_BUILDER, MR_TAGS);
+    Assert.assertEquals(EXPECTED_MR_METADATA, metadataClient.getMetadata(PURCHASE_HISTORY_BUILDER, 
                                                                          MetadataScope.USER));
 
-    metadataClient.addTags(HISTORY.toId(), DS_TAGS);
-    Assert.assertEquals(EXPECTED_DS_METADATA, metadataClient.getMetadata(HISTORY.toId(), MetadataScope.USER));
+    metadataClient.addTags(HISTORY, DS_TAGS);
+    Assert.assertEquals(EXPECTED_DS_METADATA, metadataClient.getMetadata(HISTORY, MetadataScope.USER));
 
     // there should be system metadata records for these entities
     verifySystemMetadata(PURCHASE_APP, true, true);
@@ -123,12 +123,12 @@ public class MetadataUpgradeTest extends UpgradeTestBase {
     Assert.assertTrue("PurchaseApp must exist after upgrade.", getApplicationClient().exists(PURCHASE_APP));
     MetadataClient metadataClient = getMetadataClient();
     // verify user metadata added prior to upgrade
-    Assert.assertEquals(EXPECTED_APP_METADATA, metadataClient.getMetadata(PURCHASE_APP.toId(), MetadataScope.USER));
-    Assert.assertEquals(EXPECTED_STREAM_METADATA, metadataClient.getMetadata(PURCHASE_STREAM.toId(), 
+    Assert.assertEquals(EXPECTED_APP_METADATA, metadataClient.getMetadata(PURCHASE_APP, MetadataScope.USER));
+    Assert.assertEquals(EXPECTED_STREAM_METADATA, metadataClient.getMetadata(PURCHASE_STREAM, 
                                                                              MetadataScope.USER));
-    Assert.assertEquals(EXPECTED_MR_METADATA, metadataClient.getMetadata(PURCHASE_HISTORY_BUILDER.toId(),
+    Assert.assertEquals(EXPECTED_MR_METADATA, metadataClient.getMetadata(PURCHASE_HISTORY_BUILDER,
                                                                          MetadataScope.USER));
-    Assert.assertEquals(EXPECTED_DS_METADATA, metadataClient.getMetadata(HISTORY.toId(),
+    Assert.assertEquals(EXPECTED_DS_METADATA, metadataClient.getMetadata(HISTORY,
                                                                          MetadataScope.USER));
     // verify search using user metadata added prior to upgrade
     Assert.assertEquals(
@@ -209,7 +209,7 @@ public class MetadataUpgradeTest extends UpgradeTestBase {
 
   private void verifySystemMetadata(NamespacedEntityId id, boolean checkProperties,
                                     boolean checkTags) throws Exception {
-    Set<MetadataRecord> metadataRecords = getMetadataClient().getMetadata(id.toId(), MetadataScope.SYSTEM);
+    Set<MetadataRecord> metadataRecords = getMetadataClient().getMetadata(id, MetadataScope.SYSTEM);
     Assert.assertEquals(1, metadataRecords.size());
     MetadataRecord metadata = metadataRecords.iterator().next();
     Assert.assertEquals(MetadataScope.SYSTEM, metadata.getScope());
@@ -260,7 +260,7 @@ public class MetadataUpgradeTest extends UpgradeTestBase {
   private Set<MetadataSearchResultRecord> searchMetadata(NamespaceId namespace, String query,
                                                          EntityTypeSimpleName targetType) throws Exception {
     Set<MetadataSearchResultRecord> results =
-      getMetadataClient().searchMetadata(namespace.toId(), query, targetType).getResults();
+      getMetadataClient().searchMetadata(namespace, query, targetType).getResults();
     Set<MetadataSearchResultRecord> transformed = new HashSet<>();
     for (MetadataSearchResultRecord result : results) {
       transformed.add(new MetadataSearchResultRecord(result.getEntityId()));


### PR DESCRIPTION
Fix compilation errors that arose due to https://github.com/caskdata/cdap/pull/9838.

`mvn clean package -DskipTests` passed locally.

Integration Tests (Standalone): https://builds.cask.co/browse/IT-ITS1-1