### PR TITLE
Exclude guice dependency from hadoop-yarn-common project

### DIFF
--- a/integration-test-standalone/pom.xml
+++ b/integration-test-standalone/pom.xml
@@ -159,6 +159,10 @@
           <artifactId>guava</artifactId>
         </exclusion>
         <exclusion>
+          <groupId>com.google.inject</groupId>
+          <artifactId>guice</artifactId>
+        </exclusion>
+        <exclusion>
           <groupId>org.slf4j</groupId>
           <artifactId>slf4j-api</artifactId>
         </exclusion>


### PR DESCRIPTION
Exclude guice dependency from hadoop-yarn-common project, which depends on version 3.0:

![image](https://user-images.githubusercontent.com/2440977/38393335-569d8e76-38df-11e8-9a4e-6b497b31aed6.png)


We upgraded cdap to 3.0 in https://github.com/caskdata/cdap/pull/9981.

Otherwise, when running `mvn clean test -P standalone-test`, the following error is encountered:

```
10) Error injecting method, java.lang.NoSuchMethodError: com.google.inject.spi.ProviderInstanceBinding.getUserSuppliedProvider()Ljavax/inject/Provider;
  at com.google.inject.multibindings.Multibinder$RealMultibinder.initialize(Multibinder.java:324)
  at co.cask.cdap.app.guice.InMemoryProgramRunnerModule.configure(InMemoryProgramRunnerModule.java:113)
Caused by: java.lang.NoSuchMethodError: com.google.inject.spi.ProviderInstanceBinding.getUserSuppliedProvider()Ljavax/inject/Provider;
	at com.google.inject.multibindings.Indexer.visit(Indexer.java:139)
	at com.google.inject.multibindings.Indexer.visit(Indexer.java:43)
	at com.google.inject.internal.ProviderInstanceBindingImpl.acceptTargetVisitor(ProviderInstanceBindingImpl.java:62)
	at com.google.inject.multibindings.Multibinder$RealMultibinder.initialize(Multibinder.java:332)
	at com.google.inject.multibindings.Multibinder$RealMultibinder$$FastClassByGuice$$94efefc8.invoke(<generated>)
	at com.google.inject.internal.cglib.reflect.$FastMethod.invoke(FastMethod.java:53)
	at com.google.inject.internal.SingleMethodInjector$1.invoke(SingleMethodInjector.java:56)
	at com.google.inject.internal.SingleMethodInjector.inject(SingleMethodInjector.java:90)
	at com.google.inject.internal.MembersInjectorImpl.injectMembers(MembersInjectorImpl.java:110)
	at com.google.inject.internal.MembersInjectorImpl$1.call(MembersInjectorImpl.java:75)
	at com.google.inject.internal.MembersInjectorImpl$1.call(MembersInjectorImpl.java:73)
	at com.google.inject.internal.InjectorImpl.callInContext(InjectorImpl.java:1024)
	at com.google.inject.internal.MembersInjectorImpl.injectAndNotify(MembersInjectorImpl.java:73)
	at com.google.inject.internal.Initializer$InjectableReference.get(Initializer.java:147)
	at com.google.inject.internal.Initializer.injectAll(Initializer.java:92)
	at com.google.inject.internal.InternalInjectorCreator.injectDynamically(InternalInjectorCreator.java:173)
	at com.google.inject.internal.InternalInjectorCreator.build(InternalInjectorCreator.java:109)
	at com.google.inject.Guice.createInjector(Guice.java:95)
	at com.google.inject.Guice.createInjector(Guice.java:72)
	at co.cask.cdap.StandaloneMain.<init>(StandaloneMain.java:145)
	at co.cask.cdap.StandaloneMain.create(StandaloneMain.java:442)
	at co.cask.cdap.StandaloneTester.before(StandaloneTester.java:89)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at co.cask.cdap.test.standalone.StandaloneTestSuite$1.before(StandaloneTestSuite.java:59)
	at org.junit.rules.ExternalResource$1.evaluate(ExternalResource.java:46)
	at org.junit.rules.RunRules.evaluate(RunRules.java:20)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:309)
	at org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:283)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeWithRerun(JUnit4Provider.java:173)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:153)
	at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:128)
	at org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:203)
	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:155)
	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:103)
```