### PR TITLE
add cmspark itn configs

### DIFF
--- a/conf/cmspk20r1.json
+++ b/conf/cmspk20r1.json
@@ -1,0 +1,12 @@
+{
+  "config": {
+    "cloudera_manager": {
+      "distribution_version": "5.12",
+      "csd": {
+        "install": {
+          "SPARK2": "http://archive.cloudera.com/spark2/csd/SPARK2_ON_YARN-2.0.0.cloudera1.jar"
+        }
+      }
+    }
+  }
+}

--- a/conf/cmspk20r2.json
+++ b/conf/cmspk20r2.json
@@ -1,0 +1,12 @@
+{
+  "config": {
+    "cloudera_manager": {
+      "distribution_version": "5.12",
+      "csd": {
+        "install": {
+          "SPARK2": "http://archive.cloudera.com/spark2/csd/SPARK2_ON_YARN-2.0.0.cloudera2.jar"
+        }
+      }
+    }
+  }
+}

--- a/conf/cmspk21r1.json
+++ b/conf/cmspk21r1.json
@@ -1,0 +1,12 @@
+{
+  "config": {
+    "cloudera_manager": {
+      "distribution_version": "5.12",
+      "csd": {
+        "install": {
+          "SPARK2": "http://archive.cloudera.com/spark2/csd/SPARK2_ON_YARN-2.1.0.cloudera1.jar"
+        }
+      }
+    }
+  }
+}

--- a/conf/cmspk21r2.json
+++ b/conf/cmspk21r2.json
@@ -1,0 +1,12 @@
+{
+  "config": {
+    "cloudera_manager": {
+      "distribution_version": "5.12",
+      "csd": {
+        "install": {
+          "SPARK2": "http://archive.cloudera.com/spark2/csd/SPARK2_ON_YARN-2.1.0.cloudera2.jar"
+        }
+      }
+    }
+  }
+}

--- a/conf/cmspk22r1.json
+++ b/conf/cmspk22r1.json
@@ -1,0 +1,12 @@
+{
+  "config": {
+    "cloudera_manager": {
+      "distribution_version": "5.12",
+      "csd": {
+        "install": {
+          "SPARK2": "http://archive.cloudera.com/spark2/csd/SPARK2_ON_YARN-2.2.0.cloudera1.jar"
+        }
+      }
+    }
+  }
+}

--- a/conf/cmspk22r2.json
+++ b/conf/cmspk22r2.json
@@ -1,0 +1,12 @@
+{
+  "config": {
+    "cloudera_manager": {
+      "distribution_version": "5.12",
+      "csd": {
+        "install": {
+          "SPARK2": "http://archive.cloudera.com/spark2/csd/SPARK2_ON_YARN-2.3.0.cloudera2.jar"
+        }
+      }
+    }
+  }
+}

--- a/conf/cmspk23r2.json
+++ b/conf/cmspk23r2.json
@@ -1,0 +1,12 @@
+{
+  "config": {
+    "cloudera_manager": {
+      "distribution_version": "5.12",
+      "csd": {
+        "install": {
+          "SPARK2": "http://archive.cloudera.com/spark2/csd/SPARK2_ON_YARN-2.0.0.cloudera1.jar"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
To be used in conjunction with https://builds.cask.co/browse/IT-CMSPARK2.

This integration test is a variation of the CM tests, where the version of Spark2 is varied, to test all versions here: https://www.cloudera.com/documentation/spark2/latest/topics/spark2_packaging.html.  Starting with CM 5.12 as its the most well tested at this point in time, but we should eventually just keep it at the latest CM.