### PR TITLE
fix spark2 csd version

### DIFF
--- a/conf/cmspk20r1.json
+++ b/conf/cmspk20r1.json
@@ -7,6 +7,10 @@
           "SPARK2": "http://archive.cloudera.com/spark2/csd/SPARK2_ON_YARN-2.0.0.cloudera1.jar"
         }
       }
+    },
+    "coopr_base_to_cm": {
+      "--remote-parcel-repo-url": "http://archive.cloudera.com/spark2/parcels/2.0.0.cloudera1/",
+      "--remove-remote-parcel-repo-url": "http://archive.cloudera.com/spark2/parcels/latest/"
     }
   }
 }

--- a/conf/cmspk20r2.json
+++ b/conf/cmspk20r2.json
@@ -7,6 +7,10 @@
           "SPARK2": "http://archive.cloudera.com/spark2/csd/SPARK2_ON_YARN-2.0.0.cloudera2.jar"
         }
       }
+    },
+    "coopr_base_to_cm": {
+      "--remote-parcel-repo-url": "http://archive.cloudera.com/spark2/parcels/2.0.0.cloudera2/",
+      "--remove-remote-parcel-repo-url": "http://archive.cloudera.com/spark2/parcels/latest/"
     }
   }
 }

--- a/conf/cmspk21r1.json
+++ b/conf/cmspk21r1.json
@@ -7,6 +7,10 @@
           "SPARK2": "http://archive.cloudera.com/spark2/csd/SPARK2_ON_YARN-2.1.0.cloudera1.jar"
         }
       }
+    },
+    "coopr_base_to_cm": {
+      "--remote-parcel-repo-url": "http://archive.cloudera.com/spark2/parcels/2.1.0.cloudera1/",
+      "--remove-remote-parcel-repo-url": "http://archive.cloudera.com/spark2/parcels/latest/"
     }
   }
 }

--- a/conf/cmspk22r2.json
+++ b/conf/cmspk22r2.json
@@ -4,7 +4,7 @@
       "distribution_version": "5.12",
       "csd": {
         "install": {
-          "SPARK2": "http://archive.cloudera.com/spark2/csd/SPARK2_ON_YARN-2.3.0.cloudera2.jar"
+          "SPARK2": "http://archive.cloudera.com/spark2/csd/SPARK2_ON_YARN-2.2.0.cloudera2.jar"
         }
       }
     }

--- a/conf/cmspk23r2.json
+++ b/conf/cmspk23r2.json
@@ -4,7 +4,7 @@
       "distribution_version": "5.12",
       "csd": {
         "install": {
-          "SPARK2": "http://archive.cloudera.com/spark2/csd/SPARK2_ON_YARN-2.0.0.cloudera1.jar"
+          "SPARK2": "http://archive.cloudera.com/spark2/csd/SPARK2_ON_YARN-2.3.0.cloudera2.jar"
         }
       }
     }


### PR DESCRIPTION
- [x] fix a couple incorrect spark2 csd versions, missed in the previous PR.
- [x] for versions < 2.1.0.cloudera2, cloudera's spark2 CSD incorrectly specifies the `latest` spark2 parcel repo, causing the incompatible 2.3 parcel to get installed.  this adds configuration that causes bamboo to run `coopr_base_to_cm.rb` with additional arguments to correct the parcel repo configuration