### PR TITLE
constrain cdh version for spark2.0 support

### DIFF
--- a/conf/cmspk20r1.json
+++ b/conf/cmspk20r1.json
@@ -1,7 +1,7 @@
 {
   "config": {
     "cloudera_manager": {
-      "distribution_version": "5.12",
+      "distribution_version": "5.10",
       "csd": {
         "install": {
           "SPARK2": "http://archive.cloudera.com/spark2/csd/SPARK2_ON_YARN-2.0.0.cloudera1.jar"
@@ -9,6 +9,8 @@
       }
     },
     "coopr_base_to_cm": {
+      "--cdh-parcel-version": "5.10.0",
+      "--remote-parcel-repo-url": "https://archive.cloudera.com/cdh5/parcels/5.10.0/",
       "--remote-parcel-repo-url": "http://archive.cloudera.com/spark2/parcels/2.0.0.cloudera1/",
       "--remove-remote-parcel-repo-url": "http://archive.cloudera.com/spark2/parcels/latest/"
     }

--- a/conf/cmspk20r2.json
+++ b/conf/cmspk20r2.json
@@ -1,7 +1,7 @@
 {
   "config": {
     "cloudera_manager": {
-      "distribution_version": "5.12",
+      "distribution_version": "5.10",
       "csd": {
         "install": {
           "SPARK2": "http://archive.cloudera.com/spark2/csd/SPARK2_ON_YARN-2.0.0.cloudera2.jar"


### PR DESCRIPTION
CM spark2.0 is only supported on older CDH versions as documented [here](https://www.cloudera.com/documentation/spark2/latest/topics/spark2_requirements.html#cdh_versions).  This constrains the `Spark2.0 Release1` itn to CDH 5.10.0, and the `Spark 2.0 Release 2` to CDH 5.10.x (kept it at 5.10 for consistency).

to constrain release 1 to older patch release (5.10.0), we must additionally specify the cdh parcel version (regex ok), as well as the parcel repo its available from.