### PR TITLE
use comma-separated args for multiple arguments

### DIFF
--- a/conf/cmspk20r1.json
+++ b/conf/cmspk20r1.json
@@ -10,8 +10,7 @@
     },
     "coopr_base_to_cm": {
       "--cdh-parcel-version": "5.10.0",
-      "--remote-parcel-repo-url": "https://archive.cloudera.com/cdh5/parcels/5.10.0/",
-      "--remote-parcel-repo-url": "http://archive.cloudera.com/spark2/parcels/2.0.0.cloudera1/",
+      "--remote-parcel-repo-url": "https://archive.cloudera.com/cdh5/parcels/5.10.0/,http://archive.cloudera.com/spark2/parcels/2.0.0.cloudera1/",
       "--remove-remote-parcel-repo-url": "http://archive.cloudera.com/spark2/parcels/latest/"
     }
   }


### PR DESCRIPTION
Fix itn cmspark2 provisioning failure.  We were unintentionally redefining a hash key.  Instead, use a comma-separated list, which `coopr_base_to_cm.rb` already supports for all cases where an argument can be specified multiple times.

