### PR TITLE
Bump dataset executor memory on HDP 2.6.

### DIFF
--- a/conf/dsth26.json
+++ b/conf/dsth26.json
@@ -1,5 +1,10 @@
 {
   "config": {
+    "cdap": {
+      "cdap_site": {
+        "dataset.executor.container.memory.mb": "1024"
+      },
+    },
     "hadoop": {
       "distribution": "hdp",
       "distribution_version": "2.6.3.0"


### PR DESCRIPTION
Bump dataset executor memory on HDP 2.6. I'm limiting this change to HDP 2.6, since other distros don't seem to be having their dataset executors being killed for going over the configured memory of 512mb.
We can investigate further if there is something unique to HDP 2.6 that is causing this issue.