### PR TITLE
Bump messaging service memory on HDP 2.6.

### DIFF
--- a/conf/dsth26.json
+++ b/conf/dsth26.json
@@ -2,7 +2,8 @@
   "config": {
     "cdap": {
       "cdap_site": {
-        "dataset.executor.container.memory.mb": "1024"
+        "dataset.executor.container.memory.mb": "1024",
+        "messaging.container.memory.mb": "1024"
       }
     },
     "hadoop": {


### PR DESCRIPTION
I'm limiting this change to HDP 2.6, since other distros don't seem to be having their dataset executors being killed for going over the configured memory of 512mb.
We can investigate further if there is something unique to HDP 2.6 that is causing this issue.

This is similar to: https://github.com/caskdata/cdap-integration-tests/pull/912