### PR TITLE
Bump container memory

### DIFF
--- a/conf/cdap.json
+++ b/conf/cdap.json
@@ -4,7 +4,9 @@
       "cdap_site": {
         "explore.enabled": "true",
         "cdap.ugi.cache.expiration.ms": "60000",
-        "cdap.http.client.read.timeout.ms":"120000"
+        "cdap.http.client.read.timeout.ms":"120000",
+        "dataset.executor.container.memory.mb": "1024",
+        "messaging.container.memory.mb": "1024"
       },
       "version": "4.1.0-1"
     },

--- a/conf/dsth26.json
+++ b/conf/dsth26.json
@@ -1,11 +1,5 @@
 {
   "config": {
-    "cdap": {
-      "cdap_site": {
-        "dataset.executor.container.memory.mb": "1024",
-        "messaging.container.memory.mb": "1024"
-      }
-    },
     "hadoop": {
       "distribution": "hdp",
       "distribution_version": "2.6.3.0"


### PR DESCRIPTION
Apply the changes from https://github.com/caskdata/cdap-integration-tests/pull/916 and https://github.com/caskdata/cdap-integration-tests/pull/912 to all distros.