### PR TITLE
update builds to jdk 8 to avoid https handshake failure

### DIFF
--- a/conf/all.json
+++ b/conf/all.json
@@ -2,7 +2,7 @@
   "config": {
     "java": {
       "install_flavor": "oracle",
-      "jdk_version": 7,
+      "jdk_version": 8,
       "jdk": {
         "7": {
           "x86_64": {


### PR DESCRIPTION
JDK7 is EOL.  Previously, builds were failing to download maven artifacts due to a handshake failure, even when forcing TLS v1.2.