### PR TITLE
catch additional errors to help debug during polling

### DIFF
--- a/bin/coopr-runner.rb
+++ b/bin/coopr-runner.rb
@@ -503,7 +503,7 @@ module Cask
           sleep @poll_interval
         end
         log "Cluster #{@id} is complete and active"
-      rescue RuntimeError => e
+      rescue StandardError => e
         log "ERROR: #{e.inspect}"
         log_failed_tasks
         raise e


### PR DESCRIPTION
this will catch additional errors that could happen during cluster status polling.  `RuntimeError` is a subclass of `StandardError`... refer to Ruby exception heiarchy here: https://ruby-doc.org/core-2.1.1/Exception.html