### PR TITLE
update ambari versions

### DIFF
--- a/conf/ambh24.json
+++ b/conf/ambh24.json
@@ -1,13 +1,13 @@
 {
   "config": {
     "ambari": {
-      "version": "2.4.2",
-      "rhel_6_repo": "http://public-repo-1.hortonworks.com/ambari/centos6/2.x/updates/2.4.2.0/ambari.repo",
-      "ubuntu_12_repo": "http://public-repo-1.hortonworks.com/ambari/ubuntu12/2.x/updates/2.4.2.0"
+      "version": "2.4.3",
+      "rhel_6_repo": "http://public-repo-1.hortonworks.com/ambari/centos6/2.x/updates/2.4.3.0/ambari.repo",
+      "ubuntu_12_repo": "http://public-repo-1.hortonworks.com/ambari/ubuntu12/2.x/updates/2.4.3.0"
     },
     "hadoop": {
       "distribution": "hdp",
-      "distribution_version": "2.4.3.0"
+      "distribution_version": "2.5.3.0"
     }
   }
 }

--- a/conf/ambh25.json
+++ b/conf/ambh25.json
@@ -1,13 +1,13 @@
 {
   "config": {
     "ambari": {
-      "version": "2.4.2",
-      "rhel_6_repo": "http://public-repo-1.hortonworks.com/ambari/centos6/2.x/updates/2.4.2.0/ambari.repo",
-      "ubuntu_12_repo": "http://public-repo-1.hortonworks.com/ambari/ubuntu12/2.x/updates/2.4.2.0"
+      "version": "2.5.2",
+      "rhel_6_repo": "http://public-repo-1.hortonworks.com/ambari/centos6/2.x/updates/2.5.2.0/ambari.repo",
+      "ubuntu_12_repo": "http://public-repo-1.hortonworks.com/ambari/ubuntu12/2.x/updates/2.5.2.0"
     },
     "hadoop": {
       "distribution": "hdp",
-      "distribution_version": "2.5.0.0"
+      "distribution_version": "2.6.3.0"
     }
   }
 }

--- a/conf/ambh26.json
+++ b/conf/ambh26.json
@@ -1,13 +1,13 @@
 {
   "config": {
     "ambari": {
-      "version": "2.5.1",
-      "rhel_6_repo": "http://public-repo-1.hortonworks.com/ambari/centos6/2.x/updates/2.5.0.3/ambari.repo",
-      "ubuntu_12_repo": "http://public-repo-1.hortonworks.com/ambari/ubuntu12/2.x/updates/2.5.0.3"
+      "version": "2.6.2",
+      "rhel_6_repo": "http://public-repo-1.hortonworks.com/ambari/centos6/2.x/updates/2.6.2.0/ambari.repo",
+      "ubuntu_12_repo": "http://public-repo-1.hortonworks.com/ambari/ubuntu12/2.x/updates/2.6.2.0"
     },
     "hadoop": {
       "distribution": "hdp",
-      "distribution_version": "2.6.1.0"
+      "distribution_version": "2.6.5.0"
     }
   }
 }


### PR DESCRIPTION
Update to the latest Ambari versions. 

- The coopr_base_to_ambari.rb will always install the default HDP version. 
- Previously the Ambari versions were 1 minor version behind HDP. With the release of Ambari 2.6, they caught up to HDP
- HDP 2.6.5 comes with Spark 2.3 which is NOT currently supported. I'll disable ITN for Ambari 2.6.2 until this is supported.

Ambari ITN |   |  
-- | -- | --
ambari version | default hdp version | Spark version
2.6.2 | 2.6.5 | 2.3/1.6
2.5.2 | 2.6.3 | 2.2/1.6
2.4.3 | 2.5.3 | 2.0/1.6
