### PR TITLE
Fix/support java8 checkstyle

### DIFF
--- a/integration-test-remote/src/test/java/co/cask/cdap/app/etl/realtime/DataStreamsTest.java
+++ b/integration-test-remote/src/test/java/co/cask/cdap/app/etl/realtime/DataStreamsTest.java
@@ -170,12 +170,9 @@ public class DataStreamsTest extends ETLTestBase {
   private void verifyOutput(final Table table, final String id, String firstName, String lastName)
     throws InterruptedException, ExecutionException, TimeoutException {
 
-    Tasks.waitFor(true, new Callable<Boolean>() {
-      @Override
-      public Boolean call() throws Exception {
-        Row row = table.get(Bytes.toBytes(id));
-        return row.getString("fname") != null;
-      }
+    Tasks.waitFor(true, () -> {
+      Row row = table.get(Bytes.toBytes(id));
+      return row.getString("fname") != null;
     }, 5, TimeUnit.MINUTES, 5, TimeUnit.SECONDS);
 
     Row row = table.get(Bytes.toBytes(id));

--- a/integration-test-remote/src/test/java/co/cask/cdap/app/etl/wrangler/WranglerServiceTest.java
+++ b/integration-test-remote/src/test/java/co/cask/cdap/app/etl/wrangler/WranglerServiceTest.java
@@ -71,7 +71,7 @@ public class WranglerServiceTest extends ETLTestBase {
     private final String name;
     private final int results;
 
-    public Workspace(String name, int results) {
+    Workspace(String name, int results) {
       this.name = name;
       this.results = results;
     }
@@ -82,7 +82,7 @@ public class WranglerServiceTest extends ETLTestBase {
     private final boolean save;
     private final String name;
 
-    public Recipe(List<String> directives, boolean save, String name) {
+    Recipe(List<String> directives, boolean save, String name) {
       this.directives = directives;
       this.save = save;
       this.name = name;
@@ -94,7 +94,7 @@ public class WranglerServiceTest extends ETLTestBase {
     private final int seed;
     private final int limit;
 
-    public Sampling(String method, int seed, int limit) {
+    Sampling(String method, int seed, int limit) {
       this.method = method;
       this.seed = seed;
       this.limit = limit;

--- a/pom.xml
+++ b/pom.xml
@@ -239,6 +239,13 @@
             </goals>
           </execution>
         </executions>
+        <dependencies>
+          <dependency>
+            <groupId>com.puppycrawl.tools</groupId>
+            <artifactId>checkstyle</artifactId>
+            <version>6.19</version>
+          </dependency>
+        </dependencies>
       </plugin>
       <plugin>
         <groupId>org.apache.rat</groupId>


### PR DESCRIPTION
adding `com.puppycrawl.tools` dependency similar to cdap for checkstyle. This supports java 8 syntax while building.

replaced to use lambda syntax in `DataStreamsTest` to verify if it works.
