### PR TITLE
Attempt at fixing flaky WorkflowTest#testLDA

### DIFF
--- a/integration-test-remote/src/test/java/co/cask/cdap/apps/workflow/WorkflowTest.java
+++ b/integration-test-remote/src/test/java/co/cask/cdap/apps/workflow/WorkflowTest.java
@@ -52,7 +52,6 @@ import org.junit.experimental.categories.Category;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 


### PR DESCRIPTION
Similar pattern as in https://github.com/caskdata/cdap-integration-tests/pull/927.
My understanding is that the workflow token won't be available instantly, the moment the workflow completes. Instead, a retry needs to be done, while waiting for the workflow token is available.