### PR TITLE
Retry workflow token assertions on exceptions.

### DIFF
--- a/integration-test-remote/src/test/java/co/cask/cdap/apps/workflow/WorkflowTest.java
+++ b/integration-test-remote/src/test/java/co/cask/cdap/apps/workflow/WorkflowTest.java
@@ -143,8 +143,8 @@ public class WorkflowTest extends AudiTestBase {
           assertWorkflowToken(workflowManager, config, pid, true);
         }
         return true;
-      } catch (Exception e) {
-        // retry on exception
+      } catch (AssertionError | NotFoundException e) {
+        // retry upon AssertionError or NotFoundException
         return false;
       }
     }, 30, TimeUnit.SECONDS, 500, TimeUnit.MILLISECONDS);


### PR DESCRIPTION
Similar to https://github.com/caskdata/cdap-integration-tests/pull/930, but we had missed `AssertionError`, which is not a subclass of `Exception`.