### PR TITLE
CDAP-13261 Metadata Stress Test

### DIFF
--- a/integration-test-remote/src/test/java/co/cask/cdap/apps/metadata/ProgramMetadataStressApp.java
+++ b/integration-test-remote/src/test/java/co/cask/cdap/apps/metadata/ProgramMetadataStressApp.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.apps.metadata;
+
+import co.cask.cdap.api.app.AbstractApplication;
+import co.cask.cdap.api.data.batch.Input;
+import co.cask.cdap.api.data.batch.Output;
+import co.cask.cdap.api.dataset.lib.KeyValueTable;
+import co.cask.cdap.api.mapreduce.AbstractMapReduce;
+import co.cask.cdap.api.mapreduce.MapReduceContext;
+import co.cask.cdap.api.metadata.Metadata;
+import co.cask.cdap.api.metadata.MetadataEntity;
+import co.cask.cdap.api.metadata.MetadataScope;
+import co.cask.cdap.test.Tasks;
+import com.google.common.collect.ImmutableSet;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * An app containing a MapReduce jobs which emits and delete a lot of metadata to stress the MetadataService running
+ * in dataset op executor
+ */
+public class ProgramMetadataStressApp extends AbstractApplication {
+
+  static final String APP_NAME = "AppWithMetadataProgramsStress";
+  private static final Logger LOG = LoggerFactory.getLogger(ProgramMetadataStressApp.class);
+  private static final String INPUT_DATASET = "inputDatasetStress";
+  private static final String OUTPUT_DATASET = "outputDatasetStress";
+  // TODO: This should be bumped up for larger cluster to do stress test. Make this configurable through
+  // app config pass by the test from vm arguments.
+  private static final Integer LOAD = 10;
+
+
+  @Override
+  public void configure() {
+    setName(APP_NAME);
+    addMapReduce(new StressMetadataMR());
+    // dummy datasets for metadata association
+    createDataset(INPUT_DATASET, KeyValueTable.class);
+    createDataset(OUTPUT_DATASET, KeyValueTable.class);
+  }
+
+  public static class StressMetadataMR extends AbstractMapReduce {
+    public static final String NAME = "StressMetadataMR";
+
+    @Override
+    protected void configure() {
+      setName(NAME);
+    }
+
+    @Override
+    public void initialize() throws Exception {
+      MapReduceContext context = getContext();
+      context.addInput(Input.ofDataset(INPUT_DATASET));
+      context.addOutput(Output.ofDataset(OUTPUT_DATASET));
+
+      MetadataEntity inputDS = MetadataEntity.ofDataset(getContext().getNamespace(), INPUT_DATASET);
+
+      LOG.info("Stress testing with adding tags");
+      for (int i = 0; i < LOAD; i++) {
+        MetadataEntity field = getFieldEntity(inputDS, i);
+        context.addTags(field, Integer.toString(i));
+      }
+
+      LOG.info("Waiting for all tags to be processed");
+      // wait for last field tag to be processed
+      waitForProcessing(getFieldEntity(inputDS, LOAD - 1), ImmutableSet.of(Integer.toString(LOAD - 1)));
+
+      LOG.info("Stress testing with remove tags");
+      // remove tags
+      for (int i = 0; i < LOAD; i++) {
+        MetadataEntity field = getFieldEntity(inputDS, i);
+        context.removeTags(field);
+      }
+
+      LOG.info("Waiting for all tags to be removed");
+      waitForProcessing(getFieldEntity(inputDS, LOAD - 1), Collections.emptySet());
+    }
+
+    private void waitForProcessing(MetadataEntity metadataEntity, Set<String> expectedTags)
+      throws InterruptedException, ExecutionException, TimeoutException {
+      Tasks.waitFor(true, () -> {
+        Map<MetadataScope, Metadata> metadata =
+          getContext().getMetadata(metadataEntity);
+        return expectedTags.isEmpty() ? metadata.get(MetadataScope.USER).getTags().isEmpty() :
+          metadata.get(MetadataScope.USER).getTags().containsAll(expectedTags);
+      }, 5, TimeUnit.MINUTES, 100, TimeUnit.MILLISECONDS);
+    }
+
+    private MetadataEntity getFieldEntity(MetadataEntity inputDS, int field) {
+      return MetadataEntity.builder(inputDS).appendAsType("field",
+                                                          Integer.toString(field)).build();
+    }
+  }
+}

--- a/integration-test-remote/src/test/java/co/cask/cdap/apps/metadata/ProgramMetadataStressTest.java
+++ b/integration-test-remote/src/test/java/co/cask/cdap/apps/metadata/ProgramMetadataStressTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.apps.metadata;
+
+import co.cask.cdap.proto.ProgramRunStatus;
+import co.cask.cdap.proto.ProgramType;
+import co.cask.cdap.proto.id.ApplicationId;
+import co.cask.cdap.proto.id.ProgramId;
+import co.cask.cdap.test.ApplicationManager;
+import co.cask.cdap.test.AudiTestBase;
+import co.cask.cdap.test.MapReduceManager;
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Test which uses {@link ProgramMetadataStressApp} to Stress test metadata from programs
+ */
+public class ProgramMetadataStressTest extends AudiTestBase {
+
+  private static final ApplicationId APP = TEST_NAMESPACE.app(ProgramMetadataStressApp.APP_NAME);
+  private static final ProgramId PROGRAM = APP.program(ProgramType.MAPREDUCE,
+                                                       ProgramMetadataStressApp.StressMetadataMR.NAME);
+
+  @Test
+  public void test() throws Exception {
+    ApplicationManager applicationManager = deployApplication(ProgramMetadataStressApp.class);
+    MapReduceManager mapReduceManager =
+      applicationManager.getMapReduceManager(PROGRAM.getProgram());
+    mapReduceManager.start();
+    mapReduceManager.waitForRun(ProgramRunStatus.COMPLETED, 5, TimeUnit.MINUTES);
+  }
+}


### PR DESCRIPTION
## Summary
- Adds an app for testing which emits lots of metadata from program container
- The goal is to make sure CDAP is functional and does not crash specifically dataset op executor container.
- Currently the load is very low as our clusters are small.
- TODO: This test should run it's own suite which only runs on large cluster
