### PR TITLE
Add assert for tags and props in PurchaseMetadataTest#testLineage

### DIFF
--- a/integration-test-remote/src/test/java/co/cask/cdap/apps/metadata/PurchaseMetadataTest.java
+++ b/integration-test-remote/src/test/java/co/cask/cdap/apps/metadata/PurchaseMetadataTest.java
@@ -274,6 +274,14 @@ public class PurchaseMetadataTest extends AudiTestBase {
                          ImmutableSet.of("dsTag1", "dsTag2"))
     );
 
+    Set<String> purchaseHistoryServiceTwoTags = ImmutableSet.of("serviceTag1", "serviceTag2");
+    Map<String, String> purchaseHistoryServiceTwoProps = ImmutableMap.of("spKey1", "spValue1", "spKey2", "spValue2");
+    // assert tags and props for second run.
+    Assert.assertEquals(purchaseHistoryServiceTwoTags,
+                        metadataClient.getTags(PURCHASE_HISTORY_SERVICE, MetadataScope.USER));
+    Assert.assertEquals(purchaseHistoryServiceTwoProps, metadataClient.getProperties(PURCHASE_HISTORY_SERVICE,
+                                                                                     MetadataScope.USER));
+
     waitFor(expectedTagsSecond,
             () -> metadataClient.getMetadata(PURCHASE_HISTORY_SERVICE.run(secondServiceRunId)));
 
@@ -328,7 +336,7 @@ public class PurchaseMetadataTest extends AudiTestBase {
   }
 
   private <T> void waitFor(T expected, Callable<T> callable) throws Exception {
-    Tasks.waitFor(expected, callable, 10, TimeUnit.SECONDS, 500, TimeUnit.MILLISECONDS);
+    Tasks.waitFor(expected, callable, 60, TimeUnit.SECONDS, 500, TimeUnit.MILLISECONDS);
   }
 
   private void assertArtifactSearch() throws Exception {


### PR DESCRIPTION
**Summary**

`PurchaseMetadataTest#testLineage()` test is flaky. The test fails to assert metadata for second run of the service. One potential fix is to wait more for the metadata since `getMetadata()` call  for program runs first queries Lineage store for runid and then metadata store. 

ITN Mini: https://builds.cask.co/browse/IT-ITM5-2