### PR TITLE
Use File sink plugin instead of HDFSSink plugin, for GCSTest.

### DIFF
--- a/integration-test-remote/src/test/java/co/cask/cdap/app/etl/GCSTest.java
+++ b/integration-test-remote/src/test/java/co/cask/cdap/app/etl/GCSTest.java
@@ -218,10 +218,11 @@ public class GCSTest extends ETLTestBase {
                                                    "referenceName", "gcs-input",
                                                    "path", createPath(bucket, INPUT_BLOB_NAME))));
 
-    ETLStage sink = new ETLStage("HdfsSinkStage", new ETLPlugin("HDFS",
+    ETLStage sink = new ETLStage("FileSinkStage", new ETLPlugin("File",
                                                          BatchSink.PLUGIN_TYPE,
                                                          ImmutableMap.of(
                                                            "path", createPath(bucket, OUTPUT_BLOB_NAME),
+                                                           "format", "delimited",
                                                            "referenceName", "gcs-output")));
 
     ETLBatchConfig etlConfig = ETLBatchConfig.builder("* * * * *")


### PR DESCRIPTION
Use File sink plugin instead of HDFSSink plugin, for GCSTest.

HDFS sink was deprecated (https://github.com/caskdata/hydrator-plugins/pull/787) and removed (https://github.com/caskdata/hydrator-plugins/pull/852).