### PR TITLE
Update autobuild.json to use release/5.1 branches

### DIFF
--- a/conf/autobuild.json
+++ b/conf/autobuild.json
@@ -4,17 +4,14 @@
       "git": {
         "local_user": "root",
         "repos": {
-          "cdap-navigator": {
-            "branch": "develop"
-          },
           "hydrator-plugins": {
-            "branch": "develop"
+            "branch": "release/2.1"
           },
           "mmds": {
-            "branch": "develop"
+            "branch": "release/1.1"
           },
           "dre": {
-            "branch": "develop"
+            "branch": "release/1.1"
           }
         }
       }


### PR DESCRIPTION
Update autobuild.json to use release/5.1 branches, as per https://github.com/caskdata/cdap-build/blob/release/5.1/.gitmodules

Navigator was removed here:
https://github.com/caskdata/cdap-build/commit/b9376f91083f1f1ddb07b05248c6032bf46c2a15#diff-8903239df476d7401cf9e76af0252622