### PR TITLE
Update the program report app dependency module name.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
     </dependency>
     <dependency>
       <groupId>co.cask.cdap</groupId>
-      <artifactId>cdap-program-report2_2.11</artifactId>
+      <artifactId>cdap-program-report</artifactId>
       <version>${cdap.version}</version>
     </dependency>
     <dependency>


### PR DESCRIPTION
It was renamed in https://github.com/caskdata/cdap/pull/10677.