### PR TITLE
Fix LineageUpgradeTest asserstion

### DIFF
--- a/upgrade-test/src/test/java/co/cask/cdap/upgrade/LineageUpgradeTest.java
+++ b/upgrade-test/src/test/java/co/cask/cdap/upgrade/LineageUpgradeTest.java
@@ -61,6 +61,7 @@ public class LineageUpgradeTest extends UpgradeTestBase {
     PURCHASE_STREAM.getEntityName() + "View");
   private static final DatasetId HISTORY = LINEAGE_NAMESPACE.dataset("history");
   private static final DatasetId PURCHASES = LINEAGE_NAMESPACE.dataset("purchases");
+  private static final DatasetId FREQUENT_CUSTOMERS = LINEAGE_NAMESPACE.dataset("frequentCustomers");
 
   private static final String PURCHASE_VIEW_FIELD = "purchaseViewBody";
 
@@ -121,7 +122,8 @@ public class LineageUpgradeTest extends UpgradeTestBase {
       stopTime,
       new Lineage(ImmutableSet.of(
         new Relation(HISTORY, PURCHASE_HISTORY_BUILDER, AccessType.WRITE, runId),
-        new Relation(PURCHASES, PURCHASE_HISTORY_BUILDER, AccessType.READ, runId)
+        new Relation(PURCHASES, PURCHASE_HISTORY_BUILDER, AccessType.READ, runId),
+        new Relation(FREQUENT_CUSTOMERS, PURCHASE_HISTORY_BUILDER, AccessType.UNKNOWN, runId)
       )),
       Collections.<CollapseType>emptySet());
   }


### PR DESCRIPTION
frequentCustomers dataset is used here 
https://github.com/caskdata/cdap/blob/61c3850192e2bf5d2230fe8b7cc40e247b50aac5/cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseHistoryBuilder.java#L104