### PR TITLE
add optional config to skip autobuild via extra dimensions

### DIFF
--- a/conf/autobuild_skip.json
+++ b/conf/autobuild_skip.json
@@ -1,0 +1,7 @@
+{
+  "config": {
+    "cdap_auto": {
+      "skip_build": "true"
+    }
+  }
+}


### PR DESCRIPTION
In some rare cases, it is desirable to disable autobuild for an ITN build, such as the "pre" step of the upgrade test.  This PR adds a config to disable autobuild, that can be optionally included by coopr-runner-wrapper via the `COOPR_RUNNER_WRAPPER_EXTRA_DIMENSIONS` environment variable